### PR TITLE
Lighten transparent background, small layout changes for quality of life

### DIFF
--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -1,11 +1,21 @@
 <template>
   <div id="app">
-    <color-picker :color="color"></color-picker>
-    <button @click="color = ''">Erase</button>
-    <pixel-grid :dimensions="dimensions" :grid="grid" :color="color" />
-    <button @click="generateSvgPaths()">Generate SVG</button>
-    <textarea v-model="svg"></textarea>
-    <div class="preview" ref="preview"></div>
+    <div class="content-container">
+      <div class="drawing-container">
+        <div class="drawing-actions">
+          <color-picker :color="color"></color-picker>
+          <button @click="color = ''">Erase</button>
+        </div>
+        <pixel-grid :dimensions="dimensions" :grid="grid" :color="color" />
+      </div>
+      <div class="preview-container">
+        <textarea v-model="svg"></textarea>
+        <button class="generate-svg-btn" @click="generateSvgPaths()">
+          Generate SVG
+        </button>
+        <div class="preview" ref="preview"></div>
+      </div>
+    </div>
   </div>
 </template>
 
@@ -23,8 +33,8 @@ export default {
   data: function () {
     return {
       dimensions: {
-        x: 17,
-        y: 17,
+        x: 10,
+        y: 10,
       },
       color: "#ffff00",
       grid: [],
@@ -115,10 +125,50 @@ export default {
 </script>
 
 <style lang="scss">
+*,
+*:before,
+*:after {
+  box-sizing: border-box;
+}
 #app {
   display: flex;
-  flex-wrap: wrap;
-  max-width: 500px;
-  background: #888;
+  justify-content: center;
+  align-items: flex-start;
+
+  .content-container {
+    display: flex;
+
+    .drawing-container {
+      .drawing-actions {
+        height: 50px;
+        display: flex;
+      }
+    }
+
+    .preview-container {
+      display: flex;
+      flex-direction: column;
+      min-width: 300px;
+      margin-top: 50px;
+      margin-left: 10px;
+
+      textarea {
+        min-height: 200px;
+      }
+
+      .generate-svg-btn {
+        height: 50px;
+      }
+
+      .preview {
+        background: #c0c0c0;
+
+        svg {
+          width: 100%;
+          height: auto;
+        }
+      }
+    }
+  }
 }
 </style>

--- a/client/src/assets/Transparent.svg
+++ b/client/src/assets/Transparent.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" standalone="no"?>
 <svg width="2" height="2" version="1.1" fill="transparent" xmlns="http://www.w3.org/2000/svg">
-  <rect x="0" y="0" width="1" height="1" fill="grey"/>
-  <rect x="1" y="1" width="1" height="1" fill="grey" />
+  <rect x="0" y="0" width="1" height="1" fill="#c0c0c0"/>
+  <rect x="1" y="1" width="1" height="1" fill="#c0c0c0" />
 </svg>

--- a/client/src/components/ColorPicker.vue
+++ b/client/src/components/ColorPicker.vue
@@ -1,28 +1,24 @@
 <template>
-  <input type="color" :value="color" @input="onColorChange($event)">
+  <input type="color" :value="color" @input="onColorChange($event)" />
 </template>
 
 <script>
-import EventBus from '../event-bus';
+import EventBus from "../event-bus";
 
 export default {
   name: "ColorPicker",
-  props: ['color'],
+  props: ["color"],
   methods: {
-    onColorChange: function(e) {
-      EventBus.$emit('colorChanged', e.target.value);
-    }
-  }
+    onColorChange: function (e) {
+      EventBus.$emit("colorChanged", e.target.value);
+    },
+  },
 };
 </script>
 
 <!-- Add "scoped" attribute to limit CSS to this component only -->
 <style scoped lang="scss">
-.pixel-grid {
-  background: black;
-  display: inline-grid;
-  border-top: none;
-  grid-row-gap: 1px;
-  border: 1px solid black;
+input {
+  height: 100%;
 }
 </style>


### PR DESCRIPTION
Use lighter grey for "transparent" checkboard background
Layout changes to improve quality of life and usability

![image](https://user-images.githubusercontent.com/19574304/130368845-4912ce80-e9c4-4d1c-abf2-c82d16b8158b.png)
